### PR TITLE
Resolved #76 - [BUG] Name of my_recipe_card won't change after editing

### DIFF
--- a/source/assets/components/EditRecipe.js
+++ b/source/assets/components/EditRecipe.js
@@ -703,6 +703,8 @@ class EditRecipe extends HTMLElement {
       inputData["instructions"] = listHtml;
       inputData["instructionsArray"] = instruArray;
 
+      inputData["id"] = data["id"];
+      
       updateMy(inputData);
       leaveEdit(inputData);
     });

--- a/source/assets/scripts/helpCrudFunc.js
+++ b/source/assets/scripts/helpCrudFunc.js
@@ -46,7 +46,10 @@ export function addFav(data) {
 * @returns void
 */
 export function addMy(data) {
+    data["id"] = nextMyRecipeID;
+    nextMyRecipeID += 1;
     myRecipeArray.push(data);
+    localStorage.setItem("nextMyRecipeID", JSON.stringify(nextMyRecipeID));
     localStorage.setItem("myRecipeArray", JSON.stringify(myRecipeArray));
 }
 
@@ -58,7 +61,7 @@ export function addMy(data) {
 export function updateMy(data) {
     let i = 0;
     for (; i < myRecipeArray.length; i++) {
-        if (myRecipeArray[i].title == data.title) {
+        if (myRecipeArray[i].id == data.id) {
             myRecipeArray[i] = data;
             break;
         }
@@ -73,7 +76,7 @@ export function updateMy(data) {
 export function rmMy(data) {
     let i = 0;
     for (; i < myRecipeArray.length; i++) {
-        if (myRecipeArray[i].title == data.title) {
+        if (myRecipeArray[i].id == data.id) {
             break;
         }
     }

--- a/source/assets/scripts/main.js
+++ b/source/assets/scripts/main.js
@@ -2,7 +2,7 @@
 
 const $ = (selector) => document.querySelector(selector);
 
-
+let nextMyRecipeID = JSON.parse(localStorage.getItem("nextMyRecipeID"));
 let feaRecipeArray = JSON.parse(localStorage.getItem("feaRecipeArray"));
 let myRecipeArray = JSON.parse(localStorage.getItem("myRecipeArray"));
 let favRecipeArray = JSON.parse(localStorage.getItem("favRecipeArray"));
@@ -122,6 +122,9 @@ function createFavRecipeCards() {
  */
 function createMyRecipeCards() {
   return new Promise((resolve) => {
+    if (nextMyRecipeID == null) {
+      nextMyRecipeID = 0;
+    }
     if (myRecipeArray == null) {
       myRecipeArray = [];
     }


### PR DESCRIPTION
Assign every recipes with a ID. So we could find the recipe using ID instead of recipe name. Because if recipe name was changed, we cannot change the recipe in the local storage because we cannot find the recipe in the local storage using recipe name.