### PR TITLE
Resolved #90 - [BUG] Can't submit edited recipe without image

### DIFF
--- a/source/assets/components/AddRecipe.js
+++ b/source/assets/components/AddRecipe.js
@@ -382,6 +382,7 @@ class AddRecipe extends HTMLElement {
     let picImgPreRead = document.createElement("img");
     picImgPreRead.style.display = "none";
     picImgPreRead.id = "pic-img-pre-read";
+    picImgPreRead.src = "assets/images/noPhoto.jpeg";
     picImgContainer.setAttribute("class", "recipe-image-container");
     picInput.setAttribute("type", "file");
     picInput.setAttribute("accept", "image/*");


### PR DESCRIPTION
Using default photo if no image submitted